### PR TITLE
[#23] Add Elasticache module with Redis engine

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,3 +60,13 @@ module "s3" {
   namespace   = var.namespace
   bucket_name = "main"
 }
+
+module "elasticache" {
+  source = "./modules/elasticache"
+
+  namespace = var.namespace
+  #TODO: Replace with private subnet groups when implemented
+  subnet_ids         = module.network.public_subnet_ids
+  security_group_ids = [module.network.elasticache_security_group_id]
+}
+

--- a/modules/elasticache/README.md
+++ b/modules/elasticache/README.md
@@ -1,0 +1,1 @@
+In-memory storage, redis with elasticache

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -1,0 +1,17 @@
+resource "aws_elasticache_cluster" "main" {
+  cluster_id           = "${var.namespace}-cluster"
+  engine               = var.engine
+  engine_version       = var.engine_version
+  node_type            = var.node_type
+  num_cache_nodes      = var.num_cache_nodes
+  parameter_group_name = var.parameter_group_name
+  port                 = var.port
+
+  subnet_group_name  = aws_elasticache_subnet_group.main.name
+  security_group_ids = var.security_group_ids
+}
+
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.namespace}-subnet-group"
+  subnet_ids = var.subnet_ids
+}

--- a/modules/elasticache/outputs.tf
+++ b/modules/elasticache/outputs.tf
@@ -1,0 +1,3 @@
+output "primary_endpoint_address" {
+  value = "${aws_elasticache_cluster.main.cache_nodes[0].address}:${aws_elasticache_cluster.main.cache_nodes[0].port}"
+}

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -1,0 +1,41 @@
+variable "namespace" {
+  type = string
+}
+
+variable "engine" {
+  type    = string
+  default = "redis"
+}
+
+variable "engine_version" {
+  type    = string
+  default = "6.x"
+}
+
+variable "port" {
+  type    = number
+  default = 6379
+}
+
+variable "node_type" {
+  type    = string
+  default = "cache.t3.small"
+}
+
+variable "num_cache_nodes" {
+  type    = number
+  default = 1
+}
+
+variable "parameter_group_name" {
+  type    = string
+  default = "default.redis6.x"
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "security_group_ids" {
+  type = list(string)
+}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -174,6 +174,23 @@ resource "aws_security_group" "rds_main" {
   }
 }
 
+resource "aws_security_group" "elasticache_main" {
+  name        = "elasticache_security_group"
+  description = "Security group for Elasticache"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_main.id]
+  }
+
+  tags = {
+    Name = "${var.namespace}-elasticache-sg"
+  }
+}
+
 resource "aws_alb_target_group" "main" {
   name        = "alb-ecs-target-group"
   port        = 80

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -25,3 +25,7 @@ output "ecs_security_group_id" {
 output "rds_security_group_id" {
   value = aws_security_group.rds_main.id
 }
+
+output "elasticache_security_group_id" {
+  value = aws_security_group.elasticache_main.id
+}


### PR DESCRIPTION
- #23 

**Builds from S3 bucket PR: https://github.com/liamstevens111/terraform-infrastructure-example/pull/28**

## What happened 👀

- [x] Add Elasticache module with Redis engine
- [x] Add security group for access from ECS > Elasticache

## Insight 📝

- I used a single cluster with `1` cache node and no `replication group`. Therefore there is no output variable `redis_primary_endpoint_address`. I had to use `aws_elasticache_cluster.main.cache_nodes[0]` for this information instead.

Let me know if I should change to replication group (`aws_elasticache_cluster` > `aws_elasticache_replication_group` in Terraform)

## Proof Of Work 📹

Showing Elasticache Redis cluster

<img width="1139" alt="Screenshot 2022-12-21 at 13 24 00" src="https://user-images.githubusercontent.com/8955671/208847489-98520924-4fe7-4f50-8397-a369896edc7e.png">

